### PR TITLE
Fix for boundary condition problem where pin 27 couldn't be used

### DIFF
--- a/gpio-evdev-driver.py
+++ b/gpio-evdev-driver.py
@@ -13,7 +13,7 @@ import stat
 from os.path import abspath, dirname, isfile
 from subprocess import call
 
-PINS = range(27) # BCM pin range
+PINS = range(28) # BCM pin range
 CONFIG_FILE = "config.json"
 INIT_SCRIPT = 'gpio-evdev-driver.sh'
 POLLING_INTERVAL = 0.01 # in seconds


### PR DESCRIPTION
The pin range is defined as range(27) which stops at pin 26. This causes pin 27 to be impossible to use (I have an adafruit TFT display where one of the buttons are mapped to 27). The fix increases the range to range(28) which includes pin 27.